### PR TITLE
Explicitly call nock.restore() in after()

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ module.exports = function (name, options) {
             str_fixtures = str_fixtures.replace(re, place_holders[key]);
         });
         fs.writeFileSync(fix_file, str_fixtures, 'utf-8');
+        nock.restore();
       }
       done();
     }


### PR DESCRIPTION
This allows `nockturnal.before` and `nockturnal.after` to be called
in mocha.beforeEach and mocha.afterEach. This allows fixtures for each
test to be saved to separate files.
