### PR TITLE
nock.restore() doesn't actually clear the recordings

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,8 @@ module.exports = function (name, options) {
             str_fixtures = str_fixtures.replace(re, place_holders[key]);
         });
         fs.writeFileSync(fix_file, str_fixtures, 'utf-8');
+        nock.cleanAll();
+        nock.recorder.clear();
         nock.restore();
       }
       done();


### PR DESCRIPTION
As a result, each test had the nocks saved for all previous
tests! Not what was intended...
